### PR TITLE
Update common submodule to the `main` top

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ case and deliver real-time performance. This repo provides performant client exa
 git clone https://github.com/nvidia-riva/python-clients.git
 cd python-clients
 git submodule init
-git submodule update --remote
+git submodule update --remote --recursive
 pip install -r requirements.txt
 python3 setup.py bdist_wheel
 pip install --force-reinstall dist/*.whl

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ case and deliver real-time performance. This repo provides performant client exa
 git clone https://github.com/nvidia-riva/python-clients.git
 cd python-clients
 git submodule init
-git submodule update
+git submodule update --remote
 pip install -r requirements.txt
 python3 setup.py bdist_wheel
 pip install --force-reinstall dist/*.whl

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ class BuildPyCommand(build_py):
             # # A code which may be improved in future to replace a commented block above.
             # # `git submodule` commands are preferable compared to `git clone`.
             #
-            # subprocess_args = ['git', 'submodule', 'update', '--init']
+            # subprocess_args = ['git', 'submodule', 'update', '--init', '--remote']
             # completed_git_submodule_process = sp.run(subprocess_args)
             # if completed_git_submodule_process.returncode > 0:
             #     raise RuntimeError(
@@ -84,9 +84,9 @@ class BuildPyCommand(build_py):
             if not protos:
                 raise ValueError(
                     f"No proto files matching glob {glob_dir} were found. If {setup_py_dir / 'common'} directory is "
-                    f"empty, you may try to fix it by calling `git submodule update --init`. If you unintentionally "
-                    f"removed {setup_py_dir / 'common'} content, then you may try `cd {setup_py_dir / 'common'} && "
-                    f"git stash && cd -`."
+                    f"empty, you may try to fix it by calling `git submodule update --remote --init`. If you "
+                    f"unintentionally removed {setup_py_dir / 'common'} content, then you may try "
+                    f"`cd {setup_py_dir / 'common'} && git stash && cd -`."
                 )
             for proto in glob(glob_dir):
                 print(proto)

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ class BuildPyCommand(build_py):
             # # A code which may be improved in future to replace a commented block above.
             # # `git submodule` commands are preferable compared to `git clone`.
             #
-            # subprocess_args = ['git', 'submodule', 'update', '--init', '--remote']
+            # subprocess_args = ['git', 'submodule', 'update', '--init', '--remote', '--recursive']
             # completed_git_submodule_process = sp.run(subprocess_args)
             # if completed_git_submodule_process.returncode > 0:
             #     raise RuntimeError(
@@ -84,8 +84,8 @@ class BuildPyCommand(build_py):
             if not protos:
                 raise ValueError(
                     f"No proto files matching glob {glob_dir} were found. If {setup_py_dir / 'common'} directory is "
-                    f"empty, you may try to fix it by calling `git submodule update --remote --init`. If you "
-                    f"unintentionally removed {setup_py_dir / 'common'} content, then you may try "
+                    f"empty, you may try to fix it by calling `git submodule update --remote --init --recursive`. "
+                    f"If you unintentionally removed {setup_py_dir / 'common'} content, then you may try "
                     f"`cd {setup_py_dir / 'common'} && git stash && cd -`."
                 )
             for proto in glob(glob_dir):


### PR DESCRIPTION
`common` submodule in this is behind the [common](https://github.com/nvidia-riva/common) `main` branch. This probably happened because of `git submodule update` was called without `--remote` option. This PR update `common` submodule and adds the `--remote` option to the documentation.