### PR TITLE
support file formats other than LINEAR_PCM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 setuptools>=65
 grpcio-tools
-ffmpeg-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 setuptools>=65
 grpcio-tools
+ffmpeg-python

--- a/riva/client/asr.py
+++ b/riva/client/asr.py
@@ -10,11 +10,29 @@ import wave
 from pathlib import Path
 from typing import Callable, Dict, Generator, Iterable, List, Optional, TextIO, Union
 
+import ffmpeg
 from grpc._channel import _MultiThreadedRendezvous
 
+import riva.client
 import riva.client.proto.riva_asr_pb2 as rasr
 import riva.client.proto.riva_asr_pb2_grpc as rasr_srv
 from riva.client.auth import Auth
+
+
+def get_file_encoding(input_file: Union[str, os.PathLike]) -> Dict[str, Union[int, float]]:
+    info = ffmpeg.probe(input_file)
+    if info.get("streams")[0]["codec_name"] == "pcm_s16le":
+        encoding = riva.client.AudioEncoding.LINEAR_PCM
+    elif info.get("streams")[0]["codec_name"] == "flac":
+        encoding = riva.client.AudioEncoding.FLAC
+    elif info.get("streams")[0]["codec_name"] == "pcm_alaw":
+        encoding = riva.client.AudioEncoding.ALAW
+    elif info.get("streams")[0]["codec_name"] == "pcm_mulaw":
+        encoding = riva.client.AudioEncoding.MULAW
+    elif info.get("streams")[0]["codec_name"] == "opus":
+        encoding = riva.client.AudioEncoding.OGGOPUS
+    else:
+        encoding = riva.client.AudioEncoding.ENCODING_UNSPECIFIED
 
 
 def get_wav_file_parameters(input_file: Union[str, os.PathLike]) -> Dict[str, Union[int, float]]:
@@ -46,8 +64,15 @@ class AudioChunkFileIterator:
         self.input_file: Path = Path(input_file).expanduser()
         self.chunk_n_frames = chunk_n_frames
         self.delay_callback = delay_callback
-        self.file_parameters = get_wav_file_parameters(self.input_file)
-        self.file_object: Optional[wave.Wave_read] = wave.open(str(self.input_file), 'rb')
+        self.encoding = get_file_encoding(self.input_file)
+        if self.encoding == riva.client.AudioEncoding.LINEAR_PCM:
+            self.file_parameters = get_wav_file_parameters(self.input_file)
+            self.file_object: Optional[wave.Wave_read] = wave.open(str(self.input_file), 'rb')
+        else:
+            self.file_object: Optional[wave.Wave_read] = open(str(self.input_file), 'rb')
+            if self.delay_callback:
+                warnings.warn(f"delay_callback not supported for encoding other than LINEAR_PCM")
+                self.delay_callback = None
 
     def close(self) -> None:
         self.file_object.close()
@@ -64,14 +89,16 @@ class AudioChunkFileIterator:
         return self
 
     def __next__(self) -> bytes:
-        data = self.file_object.readframes(self.chunk_n_frames)
+        if self.encoding == riva.client.AudioEncoding.LINEAR_PCM:
+            data = self.file_object.readframes(self.chunk_n_frames)
+        else:
+            data = self.file_object.read(self.chunk_n_frames)
         if not data:
             self.close()
             raise StopIteration
         if self.delay_callback is not None:
             self.delay_callback(
-                data,
-                len(data) / self.file_parameters['sampwidth'] / self.file_parameters['framerate']
+                data, len(data) / self.file_parameters['sampwidth'] / self.file_parameters['framerate']
             )
         return data
 

--- a/scripts/asr/riva_streaming_asr_client.py
+++ b/scripts/asr/riva_streaming_asr_client.py
@@ -54,7 +54,6 @@ def streaming_transcription_worker(
         asr_service = riva.client.ASRService(auth)
         config = riva.client.StreamingRecognitionConfig(
             config=riva.client.RecognitionConfig(
-                encoding=riva.client.AudioEncoding.ENCODING_UNSPECIFIED,
                 language_code=args.language_code,
                 max_alternatives=args.max_alternatives,
                 profanity_filter=args.profanity_filter,

--- a/scripts/asr/riva_streaming_asr_client.py
+++ b/scripts/asr/riva_streaming_asr_client.py
@@ -54,7 +54,7 @@ def streaming_transcription_worker(
         asr_service = riva.client.ASRService(auth)
         config = riva.client.StreamingRecognitionConfig(
             config=riva.client.RecognitionConfig(
-                encoding=riva.client.AudioEncoding.LINEAR_PCM,
+                encoding=riva.client.AudioEncoding.ENCODING_UNSPECIFIED,
                 language_code=args.language_code,
                 max_alternatives=args.max_alternatives,
                 profanity_filter=args.profanity_filter,
@@ -64,7 +64,6 @@ def streaming_transcription_worker(
             ),
             interim_results=True,
         )
-        riva.client.add_audio_file_specs_to_config(config, args.input_file)
         riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
         for _ in range(args.num_iterations):
             with riva.client.AudioChunkFileIterator(
@@ -92,8 +91,6 @@ def main() -> None:
     print("Number of clients:", args.num_clients)
     print("Number of iteration:", args.num_iterations)
     print("Input file:", args.input_file)
-    wav_parameters = get_wav_file_parameters(args.input_file)
-    print(f"File duration: {wav_parameters['duration']:.2f}s")
     threads = []
     exception_queue = queue.Queue()
     for i in range(args.num_clients):

--- a/scripts/asr/transcribe_file.py
+++ b/scripts/asr/transcribe_file.py
@@ -70,7 +70,7 @@ def main() -> None:
     asr_service = riva.client.ASRService(auth)
     config = riva.client.StreamingRecognitionConfig(
         config=riva.client.RecognitionConfig(
-            encoding=riva.client.AudioEncoding.LINEAR_PCM,
+            encoding=riva.client.AudioEncoding.ENCODING_UNSPECIFIED,
             language_code=args.language_code,
             max_alternatives=1,
             profanity_filter=args.profanity_filter,
@@ -79,7 +79,6 @@ def main() -> None:
         ),
         interim_results=True,
     )
-    riva.client.add_audio_file_specs_to_config(config, args.input_file)
     riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
     sound_callback = None
     try:

--- a/scripts/asr/transcribe_file.py
+++ b/scripts/asr/transcribe_file.py
@@ -70,7 +70,6 @@ def main() -> None:
     asr_service = riva.client.ASRService(auth)
     config = riva.client.StreamingRecognitionConfig(
         config=riva.client.RecognitionConfig(
-            encoding=riva.client.AudioEncoding.ENCODING_UNSPECIFIED,
             language_code=args.language_code,
             max_alternatives=1,
             profanity_filter=args.profanity_filter,

--- a/scripts/asr/transcribe_file_offline.py
+++ b/scripts/asr/transcribe_file_offline.py
@@ -29,7 +29,7 @@ def main() -> None:
     auth = riva.client.Auth(args.ssl_cert, args.use_ssl, args.server)
     asr_service = riva.client.ASRService(auth)
     config = riva.client.RecognitionConfig(
-        encoding=riva.client.AudioEncoding.LINEAR_PCM,
+        encoding=riva.client.AudioEncoding.ENCODING_UNSPECIFIED,
         language_code=args.language_code,
         max_alternatives=args.max_alternatives,
         profanity_filter=args.profanity_filter,
@@ -37,7 +37,6 @@ def main() -> None:
         verbatim_transcripts=not args.no_verbatim_transcripts,
         enable_word_time_offsets=args.word_time_offsets or args.speaker_diarization,
     )
-    riva.client.add_audio_file_specs_to_config(config, args.input_file)
     riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
     riva.client.add_speaker_diarization_to_config(config, args.speaker_diarization)
 

--- a/scripts/asr/transcribe_file_offline.py
+++ b/scripts/asr/transcribe_file_offline.py
@@ -29,7 +29,6 @@ def main() -> None:
     auth = riva.client.Auth(args.ssl_cert, args.use_ssl, args.server)
     asr_service = riva.client.ASRService(auth)
     config = riva.client.RecognitionConfig(
-        encoding=riva.client.AudioEncoding.ENCODING_UNSPECIFIED,
         language_code=args.language_code,
         max_alternatives=args.max_alternatives,
         profanity_filter=args.profanity_filter,


### PR DESCRIPTION
Disable setting audio encoding parameters explicitly, let Riva do the decode.