### PR TITLE
Add custom dictionary parameter to tts py-client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "common"]
 	path = common
-	url = https://github.com/nvidia-riva/common.git
-	branch = main
+	url = https://github.com/manishaj-nv/common.git
+	branch = dev/mkj/tts_add_custom_g2p

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "common"]
 	path = common
-	url = https://github.com/manishaj-nv/common.git
-	branch = dev/mkj/tts_add_custom_g2p
+	url = https://github.com/nvidia-riva/common.git
+	branch = main

--- a/riva/client/tts.py
+++ b/riva/client/tts.py
@@ -10,6 +10,27 @@ import riva.client.proto.riva_tts_pb2_grpc as rtts_srv
 from riva.client import Auth
 from riva.client.proto.riva_audio_pb2 import AudioEncoding
 import wave
+import argparse
+
+def read_file_to_dict(file_path):
+    result_list = []
+    with open(file_path, 'r') as file:
+        for line_number, line in enumerate(file, start=1):
+            line = line.strip()
+            if not line:
+                print(f"Warning: Empty line at line number {line_number}.")
+                continue
+            try:
+                key, value = line.split('  ', 1)  # Split by double space
+                result_list.append(f"{key}  {value}")
+            except ValueError:
+                print(f"Warning: Malformed line at line number {line_number}: {line}")
+                continue
+    if not result_list:
+        raise ValueError("Error: No valid entries found in the file.")
+    
+    result_string = ', '.join(result_list)
+    return result_string
 
 class SpeechSynthesisService:
     """
@@ -38,6 +59,7 @@ class SpeechSynthesisService:
         audio_prompt_encoding: AudioEncoding = AudioEncoding.LINEAR_PCM,
         quality: int = 20,
         future: bool = False,
+        user_dictionary: Optional[str] = None,
     ) -> Union[rtts.SynthesizeSpeechResponse, _MultiThreadedRendezvous]:
         """
         Synthesizes an entire audio for text :param:`text`.
@@ -81,6 +103,9 @@ class SpeechSynthesisService:
             req.zero_shot_data.encoding = audio_prompt_encoding
             req.zero_shot_data.quality = quality
 
+        if user_dictionary is not None:
+            req.user_dictionary = read_file_to_dict(user_dictionary)
+
         func = self.stub.Synthesize.future if future else self.stub.Synthesize
         return func(req, metadata=self.auth.get_auth_metadata())
 
@@ -94,6 +119,7 @@ class SpeechSynthesisService:
         audio_prompt_file: Optional[str] = None,
         audio_prompt_encoding: AudioEncoding = AudioEncoding.LINEAR_PCM,
         quality: int = 20,
+        user_dictionary: Optional[str] = None,
     ) -> Generator[rtts.SynthesizeSpeechResponse, None, None]:
         """
         Synthesizes and yields output audio chunks for text :param:`text` as the chunks
@@ -111,6 +137,7 @@ class SpeechSynthesisService:
             audio_prompt_encoding: (:obj:`AudioEncoding`): Encoding of audio prompt file, e.g. ``AudioEncoding.LINEAR_PCM``.
             quality: (:obj:`int`): This defines the number of times decoder is run. Higher number improves quality of generated
                                    audio but also takes longer to generate the audio. Ranges between 1-40.
+            user_dictionary (:obj:`str`, `optional`): A file path to a user dictionary with key-value pairs separated by double spaces.
 
         Yields:
             :obj:`riva.client.proto.riva_tts_pb2.SynthesizeSpeechResponse`: a response with output. You may find
@@ -118,6 +145,7 @@ class SpeechSynthesisService:
             <https://docs.nvidia.com/deeplearning/riva/user-guide/docs/reference/protos/protos.html#riva-proto-riva-tts-proto>`_.
             If :param:`future` is :obj:`True`, then a future object is returned. You may retrieve a response from a
             future object by calling ``result()`` method.
+            user_dictionary (:obj:`str`, `optional`): A file path to a user dictionary with key-value pairs separated by double spaces.
         """
         req = rtts.SynthesizeSpeechRequest(
             text=text,
@@ -137,5 +165,8 @@ class SpeechSynthesisService:
                 req.zero_shot_data.audio_prompt = audio_data
             req.zero_shot_data.encoding = audio_prompt_encoding
             req.zero_shot_data.quality = quality
+
+        if user_dictionary is not None:
+            req.user_dictionary = read_file_to_dict(user_dictionary)
 
         return self.stub.SynthesizeOnline(req, metadata=self.auth.get_auth_metadata())

--- a/riva/client/tts.py
+++ b/riva/client/tts.py
@@ -17,7 +17,7 @@ def add_custom_dictionary_to_config(req, custom_dictionary):
         raise ValueError("Error: Input dictionary is empty.")
     
     result_list = [f"{key}  {value}" for key, value in custom_dictionary.items()]
-    result_string = ', '.join(result_list)
+    result_string = ','.join(result_list)
     req.custom_dictionary = result_string
 
 class SpeechSynthesisService:
@@ -66,6 +66,7 @@ class SpeechSynthesisService:
                                    audio but also takes longer to generate the audio. Ranges between 1-40.
             future (:obj:`bool`, defaults to :obj:`False`): Whether to return an async result instead of usual
                 response. You can get a response by calling ``result()`` method of the future object.
+            custom_dictionary (:obj:`dict`, `optional`): Dictionary with key-value pair containing grapheme and corresponding phoneme
 
         Returns:
             :obj:`Union[riva.client.proto.riva_tts_pb2.SynthesizeSpeechResponse, grpc._channel._MultiThreadedRendezvous]`:
@@ -124,7 +125,7 @@ class SpeechSynthesisService:
             audio_prompt_encoding: (:obj:`AudioEncoding`): Encoding of audio prompt file, e.g. ``AudioEncoding.LINEAR_PCM``.
             quality: (:obj:`int`): This defines the number of times decoder is run. Higher number improves quality of generated
                                    audio but also takes longer to generate the audio. Ranges between 1-40.
-            custom_dictionary (:obj:`dict`, `optional`): Key with grapheme and corresponding phoneme shared as dictionary converted to key-value pairs separated by double spaces.
+            custom_dictionary (:obj:`dict`, `optional`): Dictionary with key-value pair containing grapheme and corresponding phoneme
 
         Yields:
             :obj:`riva.client.proto.riva_tts_pb2.SynthesizeSpeechResponse`: a response with output. You may find

--- a/riva/client/tts.py
+++ b/riva/client/tts.py
@@ -10,12 +10,8 @@ import riva.client.proto.riva_tts_pb2_grpc as rtts_srv
 from riva.client import Auth
 from riva.client.proto.riva_audio_pb2 import AudioEncoding
 import wave
-import argparse
 
 def add_custom_dictionary_to_config(req, custom_dictionary):
-    if not custom_dictionary:
-        raise ValueError("Error: Input dictionary is empty.")
-    
     result_list = [f"{key}  {value}" for key, value in custom_dictionary.items()]
     result_string = ','.join(result_list)
     req.custom_dictionary = result_string

--- a/riva/client/tts.py
+++ b/riva/client/tts.py
@@ -12,13 +12,13 @@ from riva.client.proto.riva_audio_pb2 import AudioEncoding
 import wave
 import argparse
 
-def add_custom_dictionary_to_config(req, user_dictionary):
-    if not user_dictionary:
+def add_custom_dictionary_to_config(req, custom_dictionary):
+    if not custom_dictionary:
         raise ValueError("Error: Input dictionary is empty.")
     
-    result_list = [f"{key}  {value}" for key, value in user_dictionary.items()]
+    result_list = [f"{key}  {value}" for key, value in custom_dictionary.items()]
     result_string = ', '.join(result_list)
-    req.user_dictionary = result_string
+    req.custom_dictionary = result_string
 
 class SpeechSynthesisService:
     """
@@ -47,7 +47,7 @@ class SpeechSynthesisService:
         audio_prompt_encoding: AudioEncoding = AudioEncoding.LINEAR_PCM,
         quality: int = 20,
         future: bool = False,
-        user_dictionary: Optional[dict] = None,
+        custom_dictionary: Optional[dict] = None,
     ) -> Union[rtts.SynthesizeSpeechResponse, _MultiThreadedRendezvous]:
         """
         Synthesizes an entire audio for text :param:`text`.
@@ -91,7 +91,7 @@ class SpeechSynthesisService:
             req.zero_shot_data.encoding = audio_prompt_encoding
             req.zero_shot_data.quality = quality
 
-        add_custom_dictionary_to_config(req, user_dictionary)
+        add_custom_dictionary_to_config(req, custom_dictionary)
 
         func = self.stub.Synthesize.future if future else self.stub.Synthesize
         return func(req, metadata=self.auth.get_auth_metadata())
@@ -106,7 +106,7 @@ class SpeechSynthesisService:
         audio_prompt_file: Optional[str] = None,
         audio_prompt_encoding: AudioEncoding = AudioEncoding.LINEAR_PCM,
         quality: int = 20,
-        user_dictionary: Optional[dict] = None,
+        custom_dictionary: Optional[dict] = None,
     ) -> Generator[rtts.SynthesizeSpeechResponse, None, None]:
         """
         Synthesizes and yields output audio chunks for text :param:`text` as the chunks
@@ -124,7 +124,7 @@ class SpeechSynthesisService:
             audio_prompt_encoding: (:obj:`AudioEncoding`): Encoding of audio prompt file, e.g. ``AudioEncoding.LINEAR_PCM``.
             quality: (:obj:`int`): This defines the number of times decoder is run. Higher number improves quality of generated
                                    audio but also takes longer to generate the audio. Ranges between 1-40.
-            user_dictionary (:obj:`dict`, `optional`): Key with grapheme and corresponding phoneme shared as dictionary converted to key-value pairs separated by double spaces.
+            custom_dictionary (:obj:`dict`, `optional`): Key with grapheme and corresponding phoneme shared as dictionary converted to key-value pairs separated by double spaces.
 
         Yields:
             :obj:`riva.client.proto.riva_tts_pb2.SynthesizeSpeechResponse`: a response with output. You may find
@@ -152,6 +152,6 @@ class SpeechSynthesisService:
             req.zero_shot_data.encoding = audio_prompt_encoding
             req.zero_shot_data.quality = quality
 
-        add_custom_dictionary_to_config(req, user_dictionary)                   
+        add_custom_dictionary_to_config(req, custom_dictionary)                   
 
         return self.stub.SynthesizeOnline(req, metadata=self.auth.get_auth_metadata())

--- a/scripts/tts/talk.py
+++ b/scripts/tts/talk.py
@@ -6,10 +6,28 @@ import time
 import wave
 import json
 from pathlib import Path
+import json
 
 import riva.client
 from riva.client.argparse_utils import add_connection_argparse_parameters
 
+def read_file_to_dict(file_path):
+    result_dict = {}
+    with open(file_path, 'r') as file:
+        for line_number, line in enumerate(file, start=1):
+            line = line.strip()
+            if not line:
+                print(f"Warning: Empty line at line number {line_number}.")
+                continue
+            try:
+                key, value = line.split('  ', 1)  # Split by double space
+                result_dict[str(key.strip())] = str(value.strip())
+            except ValueError:
+                print(f"Warning: Malformed line at line number {line_number}: {line}")
+                continue
+    if not result_dict:
+        raise ValueError("Error: No valid entries found in the file.")
+    return result_dict
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -42,7 +60,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sample-rate-hz", type=int, default=44100, help="Number of audio frames per second in synthesized audio."
     )
-    parser.add_argument("--user-dictionary", type=str, help="Path to user dictionary file")
+    parser.add_argument("--user-dictionary", type=str, help="A file path to a user dictionary with key-value pairs separated by double spaces.")
     parser.add_argument(
         "--stream",
         action="store_true",
@@ -109,13 +127,16 @@ def main() -> None:
             out_f.setsampwidth(sampwidth)
             out_f.setframerate(args.sample_rate_hz)
 
+        if args.user_dictionary is not None:
+            user_dictionary_input = read_file_to_dict(args.user_dictionary)
+
         print("Generating audio for request...")
         start = time.time()
         if args.stream:
             responses = service.synthesize_online(
                 args.text, args.voice, args.language_code, sample_rate_hz=args.sample_rate_hz,
                 audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality,
-                user_dictionary=args.user_dictionary
+                user_dictionary=user_dictionary_input
             )
             first = True
             for resp in responses:
@@ -131,7 +152,7 @@ def main() -> None:
             resp = service.synthesize(
                 args.text, args.voice, args.language_code, sample_rate_hz=args.sample_rate_hz,
                 audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality,
-                user_dictionary=args.user_dictionary
+                user_dictionary=user_dictionary_input
             )
             stop = time.time()
             print(f"Time spent: {(stop - start):.3f}s")

--- a/scripts/tts/talk.py
+++ b/scripts/tts/talk.py
@@ -42,6 +42,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sample-rate-hz", type=int, default=44100, help="Number of audio frames per second in synthesized audio."
     )
+    parser.add_argument("--user-dictionary", type=str, help="Path to user dictionary file")
     parser.add_argument(
         "--stream",
         action="store_true",
@@ -113,7 +114,8 @@ def main() -> None:
         if args.stream:
             responses = service.synthesize_online(
                 args.text, args.voice, args.language_code, sample_rate_hz=args.sample_rate_hz,
-                audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality
+                audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality,
+                user_dictionary=args.user_dictionary
             )
             first = True
             for resp in responses:
@@ -128,7 +130,8 @@ def main() -> None:
         else:
             resp = service.synthesize(
                 args.text, args.voice, args.language_code, sample_rate_hz=args.sample_rate_hz,
-                audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality
+                audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality,
+                user_dictionary=args.user_dictionary
             )
             stop = time.time()
             print(f"Time spent: {(stop - start):.3f}s")

--- a/scripts/tts/talk.py
+++ b/scripts/tts/talk.py
@@ -127,8 +127,8 @@ def main() -> None:
             out_f.setsampwidth(sampwidth)
             out_f.setframerate(args.sample_rate_hz)
 
-        if args.user_dictionary is not None:
-            user_dictionary_input = read_file_to_dict(args.user_dictionary)
+        if args.custom_dictionary is not None:
+            custom_dictionary_input = read_file_to_dict(args.custom_dictionary)
 
         print("Generating audio for request...")
         start = time.time()
@@ -136,7 +136,7 @@ def main() -> None:
             responses = service.synthesize_online(
                 args.text, args.voice, args.language_code, sample_rate_hz=args.sample_rate_hz,
                 audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality,
-                user_dictionary=user_dictionary_input
+                custom_dictionary=custom_dictionary_input
             )
             first = True
             for resp in responses:
@@ -152,7 +152,7 @@ def main() -> None:
             resp = service.synthesize(
                 args.text, args.voice, args.language_code, sample_rate_hz=args.sample_rate_hz,
                 audio_prompt_file=args.audio_prompt_file, quality=20 if args.quality is None else args.quality,
-                user_dictionary=user_dictionary_input
+                custom_dictionary=custom_dictionary_input
             )
             stop = time.time()
             print(f"Time spent: {(stop - start):.3f}s")

--- a/scripts/tts/talk.py
+++ b/scripts/tts/talk.py
@@ -6,7 +6,6 @@ import time
 import wave
 import json
 from pathlib import Path
-import json
 
 import riva.client
 from riva.client.argparse_utils import add_connection_argparse_parameters
@@ -16,14 +15,11 @@ def read_file_to_dict(file_path):
     with open(file_path, 'r') as file:
         for line_number, line in enumerate(file, start=1):
             line = line.strip()
-            if not line:
-                print(f"Warning: Empty line at line number {line_number}.")
-                continue
             try:
                 key, value = line.split('  ', 1)  # Split by double space
                 result_dict[str(key.strip())] = str(value.strip())
             except ValueError:
-                print(f"Warning: Malformed line at line number {line_number}: {line}")
+                print(f"Warning: Malformed line {line}")
                 continue
     if not result_dict:
         raise ValueError("Error: No valid entries found in the file.")
@@ -127,6 +123,7 @@ def main() -> None:
             out_f.setsampwidth(sampwidth)
             out_f.setframerate(args.sample_rate_hz)
 
+        custom_dictionary_input = {}
         if args.custom_dictionary is not None:
             custom_dictionary_input = read_file_to_dict(args.custom_dictionary)
 

--- a/scripts/tts/talk.py
+++ b/scripts/tts/talk.py
@@ -60,7 +60,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sample-rate-hz", type=int, default=44100, help="Number of audio frames per second in synthesized audio."
     )
-    parser.add_argument("--user-dictionary", type=str, help="A file path to a user dictionary with key-value pairs separated by double spaces.")
+    parser.add_argument("--custom-dictionary", type=str, help="A file path to a user dictionary with key-value pairs separated by double spaces.")
     parser.add_argument(
         "--stream",
         action="store_true",


### PR DESCRIPTION
This pull request introduces a addition of custom grapheme-to-phoneme dictionary for the Riva TTS client. The custom dictionary takes precedence over the default grapheme-to-phoneme rules and if a word is present in both the custom dictionary and the default rules, the custom mapping will be used.

Ensure custom handling of the dictionary is handled in the client end and is of the format key.
Read textFile and pass as string of the format to the API "ARON ˈdʒɑnsən,AARON ˈdʒɑnsən"

Usage
To use, pass the --user-dictionary flag with the path to your dictionary file when running the riva_tts_client

Example:
python3 riva/client/talk.py  --text=" Hi Aaron, this is speech synthesizer" --audio_file=/opt/riva/riva-speech/output.wav --user_dictionary=<valid_dictionary_path>