### PR TITLE
Exposing the 'stop_historu_eou_th' parameter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "common"]
 	path = common
-	url = https://github.com/sarane22/common.git
-	branch = endpointing_stop_eou_threshold_param
+	url = https://github.com/nvidia-riva/common.git
+	branch = release/2.16.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "common"]
 	path = common
-	url = https://github.com/nvidia-riva/common.git
-	branch = main
+	url = https://github.com/sarane22/common.git
+	branch = endpointing_stop_eou_threshold_param

--- a/riva/client/argparse_utils.py
+++ b/riva/client/argparse_utils.py
@@ -78,6 +78,12 @@ def add_asr_config_argparse_parameters(
         type=float,
         help="Threshold value for detecting the end of speech utterance",
     )
+    parser.add_argument(
+        "--stop-eou-threshold",
+        default=-1.0,
+        type=float,
+        help="Threshold value for likelihood of blanks before detecting end of utterance",
+    )
     return parser
 
 

--- a/riva/client/argparse_utils.py
+++ b/riva/client/argparse_utils.py
@@ -52,7 +52,7 @@ def add_asr_config_argparse_parameters(
         "--start-history",
         default=-1,
         type=int,
-        help="Value to detect and initiate start of speech utterance",
+        help="Value (in milliseconds) to detect and initiate start of speech utterance",
     )
     parser.add_argument(
         "--start-threshold",
@@ -64,19 +64,19 @@ def add_asr_config_argparse_parameters(
         "--stop-history",
         default=-1,
         type=int,
-        help="Value to reset the endpoint detection history",
-    )
-    parser.add_argument(
-        "--stop-history-eou",
-        default=-1,
-        type=int,
-        help="Value to determine the response history for endpoint detection",
+        help="Value (in milliseconds) to detect end of utterance and reset decoder",
     )
     parser.add_argument(
         "--stop-threshold",
         default=-1.0,
         type=float,
         help="Threshold value for detecting the end of speech utterance",
+    )
+    parser.add_argument(
+        "--stop-history-eou",
+        default=-1,
+        type=int,
+        help="Value (in milliseconds) to detect end of utterance for the 1st pass and generate an intermediate final transcript",
     )
     parser.add_argument(
         "--stop-threshold-eou",

--- a/riva/client/argparse_utils.py
+++ b/riva/client/argparse_utils.py
@@ -79,7 +79,7 @@ def add_asr_config_argparse_parameters(
         help="Threshold value for detecting the end of speech utterance",
     )
     parser.add_argument(
-        "--stop-eou-threshold",
+        "--stop-threshold-eou",
         default=-1.0,
         type=float,
         help="Threshold value for likelihood of blanks before detecting end of utterance",

--- a/riva/client/asr.py
+++ b/riva/client/asr.py
@@ -132,7 +132,7 @@ def add_endpoint_parameters_to_config(
     stop_threshold: float,
     stop_threshold_eou: float,
 ) -> None:
-    if not (start_history > 0 or start_threshold > 0 or stop_history > 0 or stop_history_eou > 0 or stop_threshold > 0):
+    if not (start_history > 0 or start_threshold > 0 or stop_history > 0 or stop_history_eou > 0 or stop_threshold > 0 or stop_threshold_eou > 0):
         return 
          
     inner_config: rasr.RecognitionConfig = config if isinstance(config, rasr.RecognitionConfig) else config.config

--- a/riva/client/asr.py
+++ b/riva/client/asr.py
@@ -130,6 +130,7 @@ def add_endpoint_parameters_to_config(
     stop_history: int,
     stop_history_eou: int,
     stop_threshold: float,
+    stop_eou_threshold: float,
 ) -> None:
     if not (start_history > 0 or start_threshold > 0 or stop_history > 0 or stop_history_eou > 0 or stop_threshold > 0):
         return 
@@ -146,6 +147,8 @@ def add_endpoint_parameters_to_config(
         endpointing_config.stop_history_eou = stop_history_eou
     if stop_threshold > 0:
         endpointing_config.stop_threshold = stop_threshold
+    if stop_eou_threshold > 0:
+        endpointing_config.stop_eou_threshold = stop_eou_threshold
     inner_config.endpointing_config.CopyFrom(endpointing_config)
 
 

--- a/riva/client/asr.py
+++ b/riva/client/asr.py
@@ -130,7 +130,7 @@ def add_endpoint_parameters_to_config(
     stop_history: int,
     stop_history_eou: int,
     stop_threshold: float,
-    stop_eou_threshold: float,
+    stop_threshold_eou: float,
 ) -> None:
     if not (start_history > 0 or start_threshold > 0 or stop_history > 0 or stop_history_eou > 0 or stop_threshold > 0):
         return 
@@ -147,8 +147,8 @@ def add_endpoint_parameters_to_config(
         endpointing_config.stop_history_eou = stop_history_eou
     if stop_threshold > 0:
         endpointing_config.stop_threshold = stop_threshold
-    if stop_eou_threshold > 0:
-        endpointing_config.stop_eou_threshold = stop_eou_threshold
+    if stop_threshold_eou > 0:
+        endpointing_config.stop_threshold_eou = stop_threshold_eou
     inner_config.endpointing_config.CopyFrom(endpointing_config)
 
 

--- a/scripts/asr/riva_streaming_asr_client.py
+++ b/scripts/asr/riva_streaming_asr_client.py
@@ -70,7 +70,7 @@ def streaming_transcription_worker(
             args.stop_history,
             args.stop_history_eou,
             args.stop_threshold,
-            args.stop_eou_threshold
+            args.stop_threshold_eou
         )
         riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
         for _ in range(args.num_iterations):

--- a/scripts/asr/riva_streaming_asr_client.py
+++ b/scripts/asr/riva_streaming_asr_client.py
@@ -64,12 +64,13 @@ def streaming_transcription_worker(
             interim_results=True,
         )
         riva.client.add_endpoint_parameters_to_config(
-            config, 
-            args.start_history, 
-            args.start_threshold, 
-            args.stop_history, 
-            args.stop_history_eou, 
-            args.stop_threshold
+            config,
+            args.start_history,
+            args.start_threshold,
+            args.stop_history,
+            args.stop_history_eou,
+            args.stop_threshold,
+            args.stop_eou_threshold
         )
         riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
         for _ in range(args.num_iterations):

--- a/scripts/asr/transcribe_file.py
+++ b/scripts/asr/transcribe_file.py
@@ -80,12 +80,13 @@ def main() -> None:
     )
     riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
     riva.client.add_endpoint_parameters_to_config(
-        config, 
-        args.start_history, 
-        args.start_threshold, 
-        args.stop_history, 
-        args.stop_history_eou, 
-        args.stop_threshold
+        config,
+        args.start_history,
+        args.start_threshold,
+        args.stop_history,
+        args.stop_history_eou,
+        args.stop_threshold,
+        args.stop_eou_threshold
     )
     sound_callback = None
     try:

--- a/scripts/asr/transcribe_file.py
+++ b/scripts/asr/transcribe_file.py
@@ -86,7 +86,7 @@ def main() -> None:
         args.stop_history,
         args.stop_history_eou,
         args.stop_threshold,
-        args.stop_eou_threshold
+        args.stop_threshold_eou
     )
     sound_callback = None
     try:

--- a/scripts/asr/transcribe_file_offline.py
+++ b/scripts/asr/transcribe_file_offline.py
@@ -39,12 +39,13 @@ def main() -> None:
     riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
     riva.client.add_speaker_diarization_to_config(config, args.speaker_diarization)
     riva.client.add_endpoint_parameters_to_config(
-        config, 
-        args.start_history, 
-        args.start_threshold, 
-        args.stop_history, 
-        args.stop_history_eou, 
-        args.stop_threshold
+        config,
+        args.start_history,
+        args.start_threshold,
+        args.stop_history,
+        args.stop_history_eou,
+        args.stop_threshold,
+        args.stop_eou_threshold
     )    
     with args.input_file.open('rb') as fh:
         data = fh.read()

--- a/scripts/asr/transcribe_file_offline.py
+++ b/scripts/asr/transcribe_file_offline.py
@@ -45,7 +45,7 @@ def main() -> None:
         args.stop_history,
         args.stop_history_eou,
         args.stop_threshold,
-        args.stop_eou_threshold
+        args.stop_threshold_eou
     )    
     with args.input_file.open('rb') as fh:
         data = fh.read()

--- a/scripts/asr/transcribe_mic.py
+++ b/scripts/asr/transcribe_mic.py
@@ -64,7 +64,7 @@ def main() -> None:
         args.stop_history,
         args.stop_history_eou,
         args.stop_threshold,
-        args.stop_eou_threshold
+        args.stop_threshold_eou
     )
     with riva.client.audio_io.MicrophoneStream(
         args.sample_rate_hz,

--- a/scripts/asr/transcribe_mic.py
+++ b/scripts/asr/transcribe_mic.py
@@ -58,12 +58,13 @@ def main() -> None:
     )
     riva.client.add_word_boosting_to_config(config, args.boosted_lm_words, args.boosted_lm_score)
     riva.client.add_endpoint_parameters_to_config(
-        config, 
-        args.start_history, 
-        args.start_threshold, 
-        args.stop_history, 
-        args.stop_history_eou, 
-        args.stop_threshold
+        config,
+        args.start_history,
+        args.start_threshold,
+        args.stop_history,
+        args.stop_history_eou,
+        args.stop_threshold,
+        args.stop_eou_threshold
     )
     with riva.client.audio_io.MicrophoneStream(
         args.sample_rate_hz,


### PR DESCRIPTION
With these changes, clients can now configure `stop_eou_threshold` for streaming ASR:
The new parameters introduced are:
`--stop-eou-threshold = float`