### PR TITLE
update to grpcio>=1.66.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools==70.0.0
-grpcio==1.65.4
-grpcio-tools==1.65.4
+grpcio==1.66.1
+grpcio-tools==1.66.1


### PR DESCRIPTION
Required to be compatible with tritonclient package which is built with grpcio>=1.66.1