### PR TITLE
fix(realtime): fix word timestamps not displayed in realtime ASR client

### DIFF
--- a/riva/client/realtime.py
+++ b/riva/client/realtime.py
@@ -428,15 +428,12 @@ class RealtimeClientASR:
 
                     if is_last_result:
                         logger.info("Final Transcript: %s", self.final_transcript)
-                        logger.info("Transcription completed")
-                        received_final_response = True
-                        break
                     else:
                         logger.info("Interim Transcript: %s", interim_final_transcript)
 
                     # Format Words Info similar to print_streaming function
                     words_info = event.get("words_info", {})
-                    if words_info and "words" in words_info:
+                    if self.args.word_time_offsets and words_info and words_info.get("words"):
                         print("Words Info:")
                         
                         # Create header format similar to print_streaming
@@ -456,6 +453,11 @@ class RealtimeClientASR:
                             word_format = '{: <40s}{: <16.0f}{: <16.0f}{: <16.4f}{: <16d}'
                             word_values = [word, start_time, end_time, confidence, speaker_tag]
                             print(word_format.format(*word_values))
+
+                    if is_last_result:
+                        logger.info("Transcription completed")
+                        received_final_response = True
+                        break
 
                 elif "error" in event_type.lower():
                     logger.error(


### PR DESCRIPTION
Word timestamps were never printed for final transcription results because the `break` statement appeared before the words_info display block, making it unreachable. Additionally, the words_info block lacked a check for the                                                                          --word-time-offsets flag (unlike the grpc client), causing it to always print when word data was present.                                                                                                                    
                                                                                                                                                       
Changes:                                                                                                                                             

-   Moved the break / completion logic to after the words_info display block so word timestamps are printed for final results as well (not just interim ones)
- Added a guard on self.args.word_time_offsets to match the gRPC client (transcribe_file.py) behavior
- Switched to words_info.get("words") instead of checking "words" in words_info, so we skip printing when the list is empty