### PR TITLE
fix(asr): make language code optional

### DIFF
--- a/riva/client/argparse_utils.py
+++ b/riva/client/argparse_utils.py
@@ -104,7 +104,11 @@ def add_asr_config_argparse_parameters(
         action='store_true',
         help="If specified, text inverse normalization will be applied",
     )
-    parser.add_argument("--language-code", default="en-US", help="Language code of the model to be used.")
+    parser.add_argument(
+        "--language-code",
+        default="",
+        help="Language code of the model to be used. If omitted, the server chooses auto language detection or an unambiguous language when available.",
+    )
     parser.add_argument("--model-name", default="", help="Model name to be used.")
     parser.add_argument("--boosted-lm-words", action='append', help="Words to boost when decoding. Can be used multiple times to boost multiple words.")
     parser.add_argument(


### PR DESCRIPTION
Summary:
- Stop defaulting ASR Python clients to en-US when --language-code is omitted.
- Let the server choose auto language detection or an unambiguous language when available.

Testing:
- python3 -m py_compile riva/client/argparse_utils.py
- git diff --check